### PR TITLE
Fixes capitalisation for dependency

### DIFF
--- a/plugin.edn
+++ b/plugin.edn
@@ -4,4 +4,4 @@
  :source "https://github.com/mortalapeman/LT-TernJS"
  :desc "Provides intelligent auto-complete, inline docs and jump to definition for JavaScript files in Light Table."
  :behaviors "ternjs.behaviors"
- :dependencies {:JavaScript "0.0.1"}}
+ :dependencies {:Javascript "0.0.1"}}


### PR DESCRIPTION
The plugin that Light Table uses for javascript -  'Javascript 0.0.1' - doesn't have a capital 'S', and on load, Light Table complains:

> We found that the following plugin dependencies are missing:
> JavaScript 0.0.1

This seems to stop the TernJS plugin from running.
That is fixed by this change to lower case 's'
